### PR TITLE
Fix crowns not showing for top 8 contestants

### DIFF
--- a/scripts/main.js
+++ b/scripts/main.js
@@ -89,7 +89,7 @@ function convertCSVArrayToTraineeData(csvArrays) {
     trainee.grade = traineeArray[5];
     trainee.birthyear = traineeArray[6];
     trainee.eliminated = traineeArray[7] === 'e'; // sets trainee to be eliminated if 'e' appears in 7th col
-    trainee.top8 = traineeArray[8] === 't'; // sets trainee to top 8 if 't' appears in 7th column
+    trainee.top8 = traineeArray[7] === 't'; // sets trainee to top 8 if 't' appears in 7th column
     trainee.id = parseInt(traineeArray[8]) - 1; // trainee id is the original ordering of the trainees in the first csv
     trainee.image =
       trainee.name_romanized.replaceAll(" ", "").replaceAll("-", "") + ".png";


### PR DESCRIPTION
If the 7th column of a participant's entry has a "t" in it, they are top 8, and if it has an "e" in it, they aren't.

The code correctly checks for "e" in the 7th column, but for some reason, chaecks for "t" in the **8th column**, which results in this condition never being true and no crowns being shown.

Changing this 8 to a 7 makes these contestants now show up with a crown, which I manually checked:
Eunhyung, Riel, Vanesya, Elisia, Yoona, Sunwoo, Gehlee, Hyerin.